### PR TITLE
chore: clean lint and fix blog post

### DIFF
--- a/$null
+++ b/$null
@@ -1,1 +1,0 @@
-Could Not Find C:\aytug-blog\aytug-blog\yarn.lock

--- a/content/posts/hello-world.mdx
+++ b/content/posts/hello-world.mdx
@@ -19,3 +19,5 @@ Burada blog iskeletimizi test ediyoruz.
 
 ```ts
 export const hello = (name: string) => `Merhaba, ${name}!`
+
+```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ const eslintConfig = [
       "out/**",
       "build/**",
       "next-env.d.ts",
+      ".contentlayer/**",
     ],
   },
 ];


### PR DESCRIPTION
## Summary
- ignore `.contentlayer` in eslint config
- remove stray `$null` file
- close unclosed code block in example post

## Testing
- `pnpm lint`
- `pnpm build` *(fails: TypeError e.getOwner is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68acb5f4152c832dbae765fe193a9724