### PR TITLE
feat: serve homepage data from .NET backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# backend
+backend/bin/
+backend/obj/
+backend/home.db

--- a/backend/Backend.csproj
+++ b/backend/Backend.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="LiteDB" Version="5.0.17" />
+  </ItemGroup>
+</Project>

--- a/backend/Models.cs
+++ b/backend/Models.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+public record Skill(string Name, string Level);
+public record Experience(string Company, string Role, string Period, List<string> Achievements);
+public record Project(string Title, string Summary, List<string> Tags, string Href);
+public record Post(string Title, string Date, string Summary, string Slug);
+
+public class HomeData
+{
+    public int Id { get; set; }
+    public List<string> Highlights { get; set; } = new();
+    public Dictionary<string, List<Skill>> Skills { get; set; } = new();
+    public List<Experience> Experiences { get; set; } = new();
+    public List<Project> Projects { get; set; } = new();
+    public List<Post> Posts { get; set; } = new();
+    public bool HasCv { get; set; }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,0 +1,120 @@
+using LiteDB;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddSingleton<LiteDatabase>(_ => new LiteDatabase("home.db"));
+
+var app = builder.Build();
+
+app.MapGet("/api/home", (LiteDatabase db) =>
+{
+    var col = db.GetCollection<HomeData>("home");
+    var data = col.FindById(1);
+    if (data == null)
+    {
+        data = new HomeData
+        {
+            Id = 1,
+            Highlights = new List<string>
+            {
+                "10+ yıl tecrübe",
+                ".NET 9 + Next.js",
+                "Elasticsearch & PostgreSQL",
+                "Bulut & CI/CD"
+            },
+            Skills = new Dictionary<string, List<Skill>>
+            {
+                ["Backend"] = new()
+                {
+                    new Skill(".NET", "İleri"),
+                    new Skill("EF Core", "İleri"),
+                    new Skill("PostgreSQL", "İleri"),
+                    new Skill("Redis", "Orta")
+                },
+                ["Frontend"] = new()
+                {
+                    new Skill("Next.js", "İleri"),
+                    new Skill("TypeScript", "İleri"),
+                    new Skill("Tailwind", "İleri"),
+                    new Skill("shadcn/ui", "Orta")
+                },
+                ["DevOps"] = new()
+                {
+                    new Skill("Docker", "İleri"),
+                    new Skill("GitHub Actions", "İleri"),
+                    new Skill("Vercel", "İleri"),
+                    new Skill("Fly.io", "Orta")
+                },
+                ["Data/Search"] = new()
+                {
+                    new Skill("Elasticsearch", "İleri"),
+                    new Skill("Kibana", "Orta")
+                }
+            },
+            Experiences = new List<Experience>
+            {
+                new(
+                    "Acme Corp",
+                    "Senior Engineer",
+                    "2021 – Günümüz",
+                    new List<string>
+                    {
+                        "Mikroservis mimarisiyle ölçeklenebilir API'ler tasarladım.",
+                        "%40 performans artışı sağlayan cache stratejileri geliştirdim.",
+                        "Takım mentörlüğü ve code review süreçlerini yönettim."
+                    }
+                ),
+                new(
+                    "Globex",
+                    "Fullstack Developer",
+                    "2018 – 2021",
+                    new List<string>
+                    {
+                        "React ve .NET ile kurumsal dashboard geliştirdim.",
+                        "CI/CD pipeline'ları kurarak deploy süresini %60 azalttım."
+                    }
+                ),
+                new(
+                    "Initech",
+                    "Software Engineer",
+                    "2014 – 2018",
+                    new List<string>
+                    {
+                        "Monolitik sistemi servis tabanlı mimariye taşıdım.",
+                        "Elasticsearch arama deneyimini optimize ettim."
+                    }
+                )
+            },
+            Projects = new List<Project>
+            {
+                new(
+                    "Realtime Analytics",
+                    "Gerçek zamanlı veri işleyen ve dashboard sunan SaaS platformu.",
+                    new List<string>{"Next.js", "Elasticsearch", "Redis"},
+                    "/projects/realtime-analytics"
+                ),
+                new(
+                    "E-commerce Core",
+                    "Ölçeklenebilir .NET 9 tabanlı e-ticaret çekirdek kütüphanesi.",
+                    new List<string>{".NET", "PostgreSQL", "Docker"},
+                    "/projects/ecommerce-core"
+                ),
+                new(
+                    "Team Productivity",
+                    "Takımlar için görev ve zaman yönetimi sağlayan web uygulaması.",
+                    new List<string>{"Next.js", "TypeScript", "Vercel"},
+                    "/projects/team-productivity"
+                )
+            },
+            Posts = new List<Post>
+            {
+                new("İlk Yazı", "2025-08-25", "Blog iskeletimiz hazır.", "hello-world"),
+                new("İkinci Yazı", "2025-08-25", "Blog iskeletimiz hazır. Aytug", "secon-post")
+            },
+            HasCv = false
+        };
+        col.Insert(data);
+    }
+    return Results.Json(data);
+});
+
+app.Run();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,6 @@
-import fs from "fs";
-import path from "path";
 import Image from "next/image";
 import Link from "next/link";
 import { Github, Linkedin, Twitter } from "lucide-react";
-import { allPosts } from "contentlayer/generated";
 import { SiteNavbar } from "./components/site-navbar";
 import { Section } from "@/components/section";
 import { SkillBadge } from "@/components/skill-badge";
@@ -11,100 +8,11 @@ import { TimelineItem } from "@/components/timeline-item";
 import { ProjectCard } from "@/components/project-card";
 import { PostListItem } from "@/components/post-list-item";
 
-export default function HomePage() {
-  const posts = allPosts
-    .filter((p) => p.published !== false)
-    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
-    .slice(0, 3);
-
-  const hasCV = fs.existsSync(path.join(process.cwd(), "public", "cv.pdf"));
-
-  const highlights = [
-    "10+ yıl tecrübe",
-    ".NET 9 + Next.js",
-    "Elasticsearch & PostgreSQL",
-    "Bulut & CI/CD",
-  ];
-
-  const skills = {
-    Backend: [
-      { name: ".NET", level: "İleri" },
-      { name: "EF Core", level: "İleri" },
-      { name: "PostgreSQL", level: "İleri" },
-      { name: "Redis", level: "Orta" },
-    ],
-    Frontend: [
-      { name: "Next.js", level: "İleri" },
-      { name: "TypeScript", level: "İleri" },
-      { name: "Tailwind", level: "İleri" },
-      { name: "shadcn/ui", level: "Orta" },
-    ],
-    DevOps: [
-      { name: "Docker", level: "İleri" },
-      { name: "GitHub Actions", level: "İleri" },
-      { name: "Vercel", level: "İleri" },
-      { name: "Fly.io", level: "Orta" },
-    ],
-    "Data/Search": [
-      { name: "Elasticsearch", level: "İleri" },
-      { name: "Kibana", level: "Orta" },
-    ],
-  } as const;
-
-  const experiences = [
-    {
-      company: "Acme Corp",
-      role: "Senior Engineer",
-      period: "2021 – Günümüz",
-      achievements: [
-        "Mikroservis mimarisiyle ölçeklenebilir API'ler tasarladım.",
-        "%40 performans artışı sağlayan cache stratejileri geliştirdim.",
-        "Takım mentörlüğü ve code review süreçlerini yönettim.",
-      ],
-    },
-    {
-      company: "Globex",
-      role: "Fullstack Developer",
-      period: "2018 – 2021",
-      achievements: [
-        "React ve .NET ile kurumsal dashboard geliştirdim.",
-        "CI/CD pipeline'ları kurarak deploy süresini %60 azalttım.",
-      ],
-    },
-    {
-      company: "Initech",
-      role: "Software Engineer",
-      period: "2014 – 2018",
-      achievements: [
-        "Monolitik sistemi servis tabanlı mimariye taşıdım.",
-        "Elasticsearch arama deneyimini optimize ettim.",
-      ],
-    },
-  ];
-
-  const projects = [
-    {
-      title: "Realtime Analytics",
-      summary:
-        "Gerçek zamanlı veri işleyen ve dashboard sunan SaaS platformu.",
-      tags: ["Next.js", "Elasticsearch", "Redis"],
-      href: "/projects/realtime-analytics",
-    },
-    {
-      title: "E-commerce Core",
-      summary:
-        "Ölçeklenebilir .NET 9 tabanlı e-ticaret çekirdek kütüphanesi.",
-      tags: [".NET", "PostgreSQL", "Docker"],
-      href: "/projects/ecommerce-core",
-    },
-    {
-      title: "Team Productivity",
-      summary:
-        "Takımlar için görev ve zaman yönetimi sağlayan web uygulaması.",
-      tags: ["Next.js", "TypeScript", "Vercel"],
-      href: "/projects/team-productivity",
-    },
-  ];
+export default async function HomePage() {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5000";
+  const res = await fetch(`${apiUrl}/api/home`, { cache: "no-store" });
+  const { highlights, skills, experiences, projects, posts, hasCv } =
+    await res.json();
 
   return (
     <>
@@ -139,7 +47,7 @@ export default function HomePage() {
                   >
                     Projeler
                   </Link>
-                  {hasCV ? (
+                    {hasCv ? (
                     <a
                       href="/cv.pdf"
                       download


### PR DESCRIPTION
## Summary
- add .NET 9 minimal API with LiteDB for homepage content
- fetch highlights, skills, experience, projects and posts from the backend
- ignore backend build artifacts

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68af2f8ab650832d9eeafef9e2126a8a