### PR TITLE
feat: add mongodb and docker setup

### DIFF
--- a/backend/Backend.csproj
+++ b/backend/Backend.csproj
@@ -5,6 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LiteDB" Version="5.0.17" />
+    <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
   </ItemGroup>
 </Project>

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY Backend.csproj .
+RUN dotnet restore
+COPY . .
+RUN dotnet publish -c Release -o /app/publish
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:9.0
+WORKDIR /app
+COPY --from=build /app/publish .
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "Backend.dll"]

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,14 +1,17 @@
-using LiteDB;
+using MongoDB.Driver;
 
 var builder = WebApplication.CreateBuilder(args);
-builder.Services.AddSingleton<LiteDatabase>(_ => new LiteDatabase("home.db"));
+var mongoConn = Environment.GetEnvironmentVariable("MONGO_CONNECTION_STRING") ?? "mongodb://localhost:27017";
+var mongoDbName = Environment.GetEnvironmentVariable("MONGO_DB_NAME") ?? "aytugdb";
+builder.Services.AddSingleton<IMongoClient>(_ => new MongoClient(mongoConn));
+builder.Services.AddSingleton<IMongoDatabase>(sp => sp.GetRequiredService<IMongoClient>().GetDatabase(mongoDbName));
 
 var app = builder.Build();
 
-app.MapGet("/api/home", (LiteDatabase db) =>
+app.MapGet("/api/home", (IMongoDatabase db) =>
 {
     var col = db.GetCollection<HomeData>("home");
-    var data = col.FindById(1);
+    var data = col.Find(x => x.Id == 1).FirstOrDefault();
     if (data == null)
     {
         data = new HomeData
@@ -112,7 +115,7 @@ app.MapGet("/api/home", (LiteDatabase db) =>
             },
             HasCv = false
         };
-        col.Insert(data);
+        col.InsertOne(data);
     }
     return Results.Json(data);
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  mongo:
+    image: mongo:7
+    restart: unless-stopped
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+  backend:
+    build: ./backend
+    ports:
+      - "5000:8080"
+    environment:
+      MONGO_CONNECTION_STRING: mongodb://mongo:27017
+      MONGO_DB_NAME: aytugdb
+    depends_on:
+      - mongo
+volumes:
+  mongo-data:


### PR DESCRIPTION
## Summary
- use MongoDB instead of LiteDB and read connection from env vars
- add Dockerfile for backend and docker-compose to run MongoDB

## Testing
- `apt-get update` *(fails: The repository ... is not signed)*
- `docker compose build` *(fails: command not found)*
- `dotnet build backend/Backend.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af444afb7c832dbcad273b3d5cc329