### PR TITLE
Ensure ObjectId is generated before inserting HomeData

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,4 +1,5 @@
 using MongoDB.Driver;
+using MongoDB.Bson;
 
 var builder = WebApplication.CreateBuilder(args);
 var mongoConn = Environment.GetEnvironmentVariable("MONGO_CONNECTION_STRING") ?? "mongodb://localhost:27017";
@@ -18,6 +19,10 @@ app.MapGet("/api/home", (IMongoDatabase db) =>
 app.MapPost("/api/home", (IMongoDatabase db, HomeData data) =>
 {
     var col = db.GetCollection<HomeData>("home");
+    if (data.Id == ObjectId.Empty)
+    {
+        data.Id = ObjectId.GenerateNewId();
+    }
     col.InsertOne(data);
     return Results.Created($"/api/home/{data.Id}", data);
 });


### PR DESCRIPTION
## Summary
- Generate a new ObjectId when inserting HomeData if none is provided to prevent invalid _id index specifications

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af4dab3af4832d9102a3a15d34bde6