### PR TITLE
refactor: centralize service calls

### DIFF
--- a/components/medium-editor.tsx
+++ b/components/medium-editor.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { apiFetch } from '@/services/api'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Image from '@tiptap/extension-image'
@@ -78,11 +79,10 @@ export function MediumEditor({ value = '', onChange, minHeight = 320 }: Props) {
   }, [value, editor])
 
   const uploadImage = useCallback(async (file: File) => {
-    const base = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
     const fd = new FormData()
     fd.append('file', file)
     const token = getToken()
-    const res = await fetch(`${base}/api/upload/image`, {
+    const res = await apiFetch('/api/upload/image', {
       method: 'POST',
       headers: token ? { Authorization: `Bearer ${token}` } : undefined,
       body: fd,

--- a/components/site-status-panel.tsx
+++ b/components/site-status-panel.tsx
@@ -1,5 +1,6 @@
 ﻿"use client";
 import { useEffect, useState } from "react";
+import { fetchSiteStatus } from '@/services/site';
 
 type Check = { url: string; ok: boolean; status: number; ms: number; size: number; encodingWarnings?: string[]; error?: string };
 
@@ -21,7 +22,7 @@ export function SiteStatusPanel() {
   const load = async () => {
     try {
       setError(null);
-      const res = await fetch("/api/admin/site-status", { cache: "no-store" });
+      const res = await fetchSiteStatus();
       if (!res.ok) throw new Error("Durum alınamadı");
       const j = await res.json();
       setData(j);

--- a/components/visit-tracker.tsx
+++ b/components/visit-tracker.tsx
@@ -1,11 +1,11 @@
 "use client"
 import { useEffect } from 'react'
+import { apiFetch } from '@/services/api'
 
 export function VisitTracker() {
   useEffect(() => {
-    const base = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
     // fire-and-forget; ignore errors
-    fetch(`${base}/api/track/visit`, { method: 'POST' }).catch(() => {})
+    apiFetch('/api/track/visit', { method: 'POST' }).catch(() => {})
   }, [])
   return null
 }

--- a/src/app/admin/home/form/page.tsx
+++ b/src/app/admin/home/form/page.tsx
@@ -1,5 +1,6 @@
 ﻿"use client"
 import { useEffect, useMemo, useState } from 'react'
+import { apiFetch } from '@/services/api'
 
 type Skill = { Name: string; Level: string } // store Level as numeric string like "95"
 type Experience = { CompanyName: string; Tag: string; BeginDate: string; EndDate: string; WorkDescription: string }
@@ -29,7 +30,6 @@ const DEFAULT_DATA: HomeData = {
 }
 
 export default function AdminHomeFormPage() {
-  const base = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
   const [data, setData] = useState<HomeData>(DEFAULT_DATA)
   const [loading, setLoading] = useState(false)
   const [msg, setMsg] = useState<string | null>(null)
@@ -50,7 +50,7 @@ export default function AdminHomeFormPage() {
       setMsg(null)
       setErr(null)
       try {
-        const res = await fetch(`${base}/api/home`)
+        const res = await apiFetch('/api/home')
         if (res.status === 404) {
           setData(DEFAULT_DATA)
           setSavedSnapshot(JSON.stringify(toApiPayload(DEFAULT_DATA)))
@@ -69,7 +69,7 @@ export default function AdminHomeFormPage() {
         setLoading(false)
       }
     })()
-  }, [base])
+  }, [])
 
   // Warn user before leaving when there are unsaved changes
   useEffect(() => {
@@ -113,7 +113,7 @@ export default function AdminHomeFormPage() {
     try {
       const token = getToken()
       if (!token) throw new Error('Oturum bulunamadÄ±')
-      const res = await fetch(`${base}/api/home/upsert`, {
+      const res = await apiFetch('/api/home/upsert', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -144,7 +144,7 @@ export default function AdminHomeFormPage() {
       if (!token) throw new Error('Oturum bulunamadÄ±')
       const fd = new FormData()
       fd.append('file', cvFile)
-      const res = await fetch(`${base}/api/upload/cv`, {
+      const res = await apiFetch('/api/upload/cv', {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
         body: fd,
@@ -168,8 +168,7 @@ export default function AdminHomeFormPage() {
       setErr(null)
       setMsg(null)
       try {
-        const base = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
-        await fetch(`${base}/api/track/cv`, { method: 'POST' })
+        await apiFetch('/api/track/cv', { method: 'POST' })
       } catch {}
       const res = await fetch('/cv.pdf', { cache: 'no-store' })
       if (!res.ok) throw new Error('CV bulunamadÃ„Â±')

--- a/src/app/admin/home/page.tsx
+++ b/src/app/admin/home/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { useEffect, useState } from 'react'
+import { apiFetch } from '@/services/api'
 
 type HomeData = {
   Id?: string
@@ -38,8 +39,6 @@ export default function AdminHomeDataPage() {
   const [msg, setMsg] = useState<string | null>(null)
   const [err, setErr] = useState<string | null>(null)
 
-  const base = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
-
   useEffect(() => {
     refresh()
   }, [])
@@ -49,7 +48,7 @@ export default function AdminHomeDataPage() {
     setMsg(null)
     setErr(null)
     try {
-      const res = await fetch(`${base}/api/home`)
+      const res = await apiFetch('/api/home')
       if (res.status === 404) {
         setJsonText(JSON.stringify(SAMPLE, null, 2))
         setMsg('HenÃ¼z veri yok. Åablon Yüklendi.')
@@ -74,7 +73,7 @@ export default function AdminHomeDataPage() {
       const token = getToken()
       if (!token) throw new Error('Oturum bulunamadıÄ±')
       const body = JSON.parse(jsonText)
-      const res = await fetch(`${base}/api/home/upsert`, {
+      const res = await apiFetch('/api/home/upsert', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -100,7 +99,7 @@ export default function AdminHomeDataPage() {
     try {
       const token = getToken()
       if (!token) throw new Error('Oturum bulunamadıÄ±')
-      const res = await fetch(`${base}/api/home`, {
+      const res = await apiFetch('/api/home', {
         method: 'DELETE',
         headers: { Authorization: `Bearer ${token}` },
       })

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { useEffect, useState } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
+import { apiFetch } from '@/services/api'
 
 export default function AdminLoginPage() {
   const router = useRouter()
@@ -17,8 +18,7 @@ export default function AdminLoginPage() {
     setLoading(true)
     setError(null)
     try {
-      const base = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
-      const res = await fetch(`${base}/api/auth/login`, {
+      const res = await apiFetch('/api/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password }),

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { SiteStatusPanel } from '@/components/site-status-panel'
+import { apiFetch } from '@/services/api'
 
 type Me = { name: string; roles: string[] }
 type Stats = { projects: number; posts: number; visitors: number; cvDownloads: number }
@@ -15,15 +16,14 @@ export default function AdminDashboard() {
   useEffect(() => {
     const token = getToken()
     if (!token) return
-    const base = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
-    fetch(`${base}/api/auth/me`, { headers: { Authorization: `Bearer ${token}` } })
+    apiFetch('/api/auth/me', { headers: { Authorization: `Bearer ${token}` } })
       .then(async (r) => {
         if (!r.ok) throw new Error('Yetkilendirme başarısız')
         const d = (await r.json()) as Me
         setMe(d)
       })
       .catch((e) => setError(e.message))
-    fetch(`${base}/api/stats`, { headers: { Authorization: `Bearer ${token}` } })
+    apiFetch('/api/stats', { headers: { Authorization: `Bearer ${token}` } })
       .then(async (r) => {
         if (!r.ok) return
         const s = (await r.json()) as Stats

--- a/src/app/admin/posts/[key]/edit/page.tsx
+++ b/src/app/admin/posts/[key]/edit/page.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { MediumEditor } from '@/components/medium-editor'
+import { apiFetch } from '@/services/api'
 
 function getToken(): string | null {
   const m = document.cookie.match(/(?:^|; )token=([^;]+)/)
@@ -28,7 +29,6 @@ function slugify(input: string): string {
 
 export default function NewPostPage() {
   const router = useRouter()
-  const base = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
   const today = new Date().toISOString().slice(0, 10)
 
   const [title, setTitle] = useState('')
@@ -61,7 +61,7 @@ export default function NewPostPage() {
         body,
         published,
       }
-      const res = await fetch(`${base}/api/posts`, {
+      const res = await apiFetch('/api/posts', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify(payload),

--- a/src/app/admin/posts/new/page.tsx
+++ b/src/app/admin/posts/new/page.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { MediumEditor } from '@/components/medium-editor'
+import { apiFetch } from '@/services/api'
 
 function getToken(): string | null {
   const m = document.cookie.match(/(?:^|; )token=([^;]+)/)
@@ -28,7 +29,6 @@ function slugify(input: string): string {
 
 export default function NewPostPage() {
   const router = useRouter()
-  const base = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
   const today = new Date().toISOString().slice(0, 10)
 
   const [title, setTitle] = useState('')
@@ -61,7 +61,7 @@ export default function NewPostPage() {
         body,
         published,
       }
-      const res = await fetch(`${base}/api/posts`, {
+      const res = await apiFetch('/api/posts', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify(payload),

--- a/src/app/admin/posts/page.tsx
+++ b/src/app/admin/posts/page.tsx
@@ -1,10 +1,10 @@
 "use client"
 import { useEffect, useState } from 'react'
+import { apiFetch } from '@/services/api'
 
 type Post = { id: string; title: string; date: string; summary: string; slug: string; tags?: string[] }
 
 export default function AdminPostsPage() {
-  const base = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
   const [posts, setPosts] = useState<Post[]>([])
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
@@ -14,7 +14,7 @@ export default function AdminPostsPage() {
       setLoading(true)
       setError(null)
       try {
-        const res = await fetch(`${base}/api/posts`, { cache: 'no-store' })
+        const res = await apiFetch('/api/posts')
         if (!res.ok) throw new Error('Postlar alınamadı')
         const data = await res.json()
         setPosts(Array.isArray(data) ? data : [])
@@ -24,7 +24,7 @@ export default function AdminPostsPage() {
         setLoading(false)
       }
     })()
-  }, [base])
+  }, [])
 
   return (
     <div className="space-y-4">

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { SiteNavbar } from "../../components/site-navbar";
 import { Mdx } from "../../components/mdx";
+import { apiFetch } from '@/services/api';
 
 export async function generateMetadata(
   { params }: { params: Promise<{ slug: string }> }
@@ -19,9 +20,8 @@ export default async function PostPage(
   const { slug } = await params;
   const post = allPosts.find(p => p.slug === slug);
   if (!post) {
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5000";
     try {
-      const res = await fetch(`${apiUrl}/api/posts/${slug}`, { cache: "no-store" });
+      const res = await apiFetch(`/api/posts/${slug}`);
       if (res.ok) {
         const p = await res.json();
         const date = typeof p.date === 'string' ? p.date : '';

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -2,9 +2,9 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { SiteNavbar } from "../components/site-navbar";
+import { apiFetch } from '@/services/api';
 
 export default function BlogList() {
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5000";
   const [q, setQ] = useState("");
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const [apiPosts, setApiPosts] = useState<Array<{ title: string; date: string; summary: string; slug: string; tags?: string[] }>>([]);
@@ -14,7 +14,7 @@ export default function BlogList() {
     let ignore = false;
     (async () => {
       try {
-        const res = await fetch(`${apiUrl}/api/posts`, { cache: "no-store" });
+        const res = await apiFetch('/api/posts');
           console.log("Fetched API posts:", res);
         if (res.ok) {
           const data = await res.json();
@@ -38,7 +38,7 @@ export default function BlogList() {
     return () => {
       ignore = true;
     };
-  }, [apiUrl]);
+  }, []);
 
   const posts = useMemo(() => {
     const base = apiPosts

--- a/src/app/components/site-status-panel.tsx
+++ b/src/app/components/site-status-panel.tsx
@@ -1,5 +1,6 @@
 ﻿"use client";
 import { useEffect, useState } from "react";
+import { fetchSiteStatus } from '@/services/site';
 
 type Check = { url: string; ok: boolean; status: number; ms: number; size: number; encodingWarnings?: string[]; error?: string }
 
@@ -21,7 +22,7 @@ export function SiteStatusPanel() {
   const load = async () => {
     try {
       setError(null);
-      const res = await fetch('/api/admin/site-status', { cache: 'no-store' });
+      const res = await fetchSiteStatus();
       if (!res.ok) throw new Error('Durum alınamadı');
       const j = await res.json();
       setData(j);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import { PostListItem } from "@/components/post-list-item";
 import { Entrance3D } from "@/components/entrance-3d";
 import { CodeBackground } from "./components/codebackground";
 import { CornerCoder } from "@/components/corner-coder";
+import { apiFetch } from '@/services/api';
 
 const labelOngoingTitle = "\u00DCzerinde \u00C7al\u0131\u015Ft\u0131\u011F\u0131m Projeler";
 const labelOngoingDesc = "Tamamlanma y\u00FCzdesi ile g\u00FCncel durum";
@@ -18,7 +19,6 @@ const labelExperienceTitle = "Deneyim Zaman \u00C7izelgesi";
 const labelSelectedProjectsTitle = "Se\u00E7ili Projeler";
 
 export default async function HomePage() {
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5000";
   let errorMessage: string | null = null;
 
   type Experience = {
@@ -51,8 +51,8 @@ export default async function HomePage() {
   let postsFromApi: Post[] = [];
   try {
     const [homeRes, postsRes] = await Promise.all([
-      fetch(`${apiUrl}/api/home`, { cache: "no-store" }),
-      fetch(`${apiUrl}/api/posts`, { cache: "no-store" })
+      apiFetch('/api/home'),
+      apiFetch('/api/posts')
     ]);
     if (homeRes.ok) data = await homeRes.json();
     if (postsRes.ok) postsFromApi = await postsRes.json();

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,6 +1,7 @@
 import { SiteNavbar } from "../components/site-navbar";
 import { Section } from "@/components/section";
 import { ProjectCard } from "@/components/project-card";
+import { apiFetch } from '@/services/api';
 
 type RawProject = {
   projectName?: string;
@@ -44,11 +45,9 @@ function normalizeProject(p: RawProject) {
 }
 
 export default async function ProjectsPage() {
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5000";
-
   let rawProjects: RawProject[] = [];
   try {
-    const res = await fetch(`${apiUrl}/api/home`, { cache: "no-store" });
+    const res = await apiFetch('/api/home');
     if (res.ok) {
       const data = await res.json();
       rawProjects = Array.isArray(data?.projects) ? data.projects : [];

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,5 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000';
+
+export async function apiFetch(path: string, init?: RequestInit) {
+  return fetch(`${API_BASE}${path}`, { cache: 'no-store', ...init });
+}

--- a/src/services/site.ts
+++ b/src/services/site.ts
@@ -1,0 +1,3 @@
+export function fetchSiteStatus() {
+  return fetch('/api/admin/site-status', { cache: 'no-store' });
+}


### PR DESCRIPTION
## Summary
- add `apiFetch` helper and `fetchSiteStatus` under new `services` folder
- refactor components and pages to use centralized service helpers

## Testing
- `pnpm lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b666d3ba68832d88a1c2ba84fff6ba